### PR TITLE
FEAT: safe go rutine 생성

### DIFF
--- a/cmd/docker-mgr/main.go
+++ b/cmd/docker-mgr/main.go
@@ -45,7 +45,7 @@ func main() {
 	utils.SafeGoRoutineCtx(ctx, func() {
 		redisops.SubscribeExpiredKeys(ctx, redisClient, func(containerID string) {
 			log.Printf("Expired container detached: %s\n", containerID)
-			go dockerops.RemoveContainer(ctx, deps, containerID)
+			dockerops.RemoveContainer(ctx, deps, containerID)
 		})
 	})
 

--- a/cmd/docker-mgr/main.go
+++ b/cmd/docker-mgr/main.go
@@ -10,6 +10,7 @@ import (
 	"docker-server-mgr/internal/mysqlops"
 	"docker-server-mgr/internal/redisops"
 	"docker-server-mgr/internal/server"
+	"docker-server-mgr/utils"
 )
 
 func main() {
@@ -36,16 +37,22 @@ func main() {
 	}
 
 	// HTTP server 리스너 시작 (listen + 요청마다 thread 생성)
-	go server.StartHTTPServer(ctx, deps)
+	utils.SafeGoRoutineCtx(ctx, func() {
+		server.StartHTTPServer(ctx, deps)
+	})
 
 	// Redis docker container TTL 만료 감시 thread
-	go redisops.SubscribeExpiredKeys(ctx, redisClient, func(containerID string) {
-		log.Printf("Expired container detached: %s\n", containerID)
-		go dockerops.RemoveContainer(ctx, deps, containerID)
+	utils.SafeGoRoutineCtx(ctx, func() {
+		redisops.SubscribeExpiredKeys(ctx, redisClient, func(containerID string) {
+			log.Printf("Expired container detached: %s\n", containerID)
+			go dockerops.RemoveContainer(ctx, deps, containerID)
+		})
 	})
 
 	// 3. docker life sycle 감시 thread
-	go monitor.CheckDockerStatus(ctx, deps)
+	utils.SafeGoRoutineCtx(ctx, func() {
+		monitor.CheckDockerStatus(ctx, deps)
+	})
 
 	// main block
 	select {}

--- a/utils/gorutine.go
+++ b/utils/gorutine.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+/*
+function를 고루틴에서 실행하고,
+panic 시 복구한 뒤 일정 대기 후 재실행을 무한 반복.
+ctx가 취소되면 루프를 종료함.
+*/
+func SafeGoRoutineCtx(ctx context.Context, f func()) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				// 컨텍스트 취소 시 루프 종료
+				return
+			default:
+			}
+
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("Recovered from panic: %v", r)
+					}
+				}()
+				// 실제 작업 함수
+				f()
+			}()
+
+			log.Println("SafeGoRoutine: function exited, restarting in 1s...")
+			// 재시작 전 잠시 대기
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(1 * time.Second):
+			}
+		}
+	}()
+}


### PR DESCRIPTION
*  go routine 내부에서 panic 발생 시 앱 전체 크래시를 방지하고, 안전하게 로그를 남긴 후 종료되도록 감싸는 보호용 wrapper 추가
* 반복 루프를 통해 해당 goroutine은 자동 재기동되도록 구성