### PR TITLE
FIX: Redis TTL 이벤트 감지 후 제대로 삭제 플로우가 진행되지 않는 버그 수정

### DIFF
--- a/internal/redisops/subscriver.go
+++ b/internal/redisops/subscriver.go
@@ -25,8 +25,14 @@ func SubscribeExpiredKeys(ctx context.Context, rdb *redis.Client, handler func(c
 				return
 			}
 			key := msg.Payload
+
 			if strings.HasPrefix(key, "container:") {
 				id := strings.TrimPrefix(key, "container:")
+				if id == "" {
+					log.Println("Received invalid container ID from Redis")
+					continue
+				}
+				log.Printf("Container expired: %s\n", id)
 				handler(id)
 			}
 		}


### PR DESCRIPTION
* 이미 서버에 해당 컨테이너가 존재하지 않을 경우 TTL 재등록하지 않도록 예외처리 추가
* TTL 만료 이벤트 감지에서 컨테이너id 값이 빈값일 경우 remove 로직 실행하지 않고 건너뛰도록 예외처리 추가