### PR TITLE
FEAT: create 요청에 user id 추가 및 vaildation 추가

### DIFF
--- a/internal/common/errs/error.go
+++ b/internal/common/errs/error.go
@@ -1,0 +1,13 @@
+package errs
+
+type Code int
+
+const (
+	Invaild Code = iota + 1
+	DefaultSet
+)
+
+type ErrorDetail struct {
+	Code    int
+	Message error
+}

--- a/internal/common/request/types.go
+++ b/internal/common/request/types.go
@@ -6,10 +6,11 @@ type PortMapping struct {
 }
 
 type CreateRequest struct {
+	UserId        int64         `json:"user_id"` // 사용자 ID
 	Image         string        `json:"image"`
 	Tag           string        `json:"tag"`            // Docker 이미지 태그
 	ContainerName string        `json:"container_name"` // 컨테이너 이름
-	Cmd           []string      `json:"cmd"`
+	Cmd           []string      `json:"cmds"`
 	Ports         []PortMapping `json:"ports"`   // 포트 매핑 정보
 	TTL           int           `json:"ttl"`     // 단위: 초
 	Volumes       []string      `json:"volumes"` // 호스트 디렉토리 바인딩

--- a/internal/dockerops/client.go
+++ b/internal/dockerops/client.go
@@ -3,6 +3,8 @@ package dockerops
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 
 	"github.com/docker/docker/client"
 )
@@ -23,8 +25,25 @@ func GetContainerStatus(
 
 	containerJSON, err := cli.ContainerInspect(ctx, containerID)
 	if err != nil {
+		log.Printf("Error inspecting container %s: %v", containerID, err)
 		return "", fmt.Errorf("inspect error: %w", err)
 	}
 
 	return containerJSON.State.Status, nil
+}
+
+func GetContainerName(
+	ctx context.Context,
+	cli *client.Client,
+	containerID string,
+) (string, error) {
+	inspect, err := cli.ContainerInspect(ctx, containerID)
+	if err != nil {
+		log.Printf("Error inspecting container %s: %v", containerID, err)
+		return "", err
+	}
+	name := inspect.Name
+	log.Println("Container name:", strings.TrimPrefix(name, "/"))
+
+	return strings.TrimPrefix(name, "/"), nil
 }


### PR DESCRIPTION
* 필수 정보가 오지 않았을 시 bad request로 return하기 위한 함수 추가
* 컨테이너 이름은 안왔을 시 default값으로 생성할 수 있도록 추가
* 컨테이너 생성 후 상태가 running으로 바뀌지 않는 경우는 제대로 생성된 경우가 아니므로, 삭제처리하고 실패로 응답하도록 추가
* 컨테이너 이름 조회할 수 있도록 함수 추가
* 컨테이너 생성 후 상태 조회 시 실패에대한 로그 추가
* cmd -> cmds로 변경
* user가 생성한 컨테이너 조회할 수 있도록 user_id 받아 저저장하도록 추가
