### PR TITLE
FEAT: 사용하지 않는 image 모니터링해서 정리되도록 thread 추가

### DIFF
--- a/cmd/docker-mgr/main.go
+++ b/cmd/docker-mgr/main.go
@@ -60,6 +60,11 @@ func main() {
 		monitor.CheckDockerStatus(ctx, deps)
 	})
 
+	// 4. docker 사용중이지 않은 image 관리 thread
+	utils.SafeGoRoutineCtx(ctx, func() {
+		monitor.CheckImageStatus(ctx, deps)
+	})
+
 	// main block
 	select {}
 }

--- a/internal/dockerops/image.go
+++ b/internal/dockerops/image.go
@@ -1,0 +1,124 @@
+package dockerops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	shptypes "docker-server-mgr/internal/dockerops/types"
+	"docker-server-mgr/internal/mysqlops"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+)
+
+func WatchImageUsingStatus(
+	ctx context.Context,
+	dockerClient *client.Client,
+	mysqlClient *sql.DB,
+) {
+
+	mapDbImage, err := getSavedImageInfo(mysqlClient)
+	if mapDbImage == nil {
+		log.Printf("getSavedImageInfo failed: %v", err)
+		panic(err)
+	}
+
+	containers, err := dockerClient.ContainerList(ctx, types.ContainerListOptions{All: true})
+	if err != nil {
+		log.Printf("Error listing containers: %v", err)
+		panic(err)
+	}
+
+	usedImageIDs := make(map[string]bool)
+	for _, c := range containers {
+		usedImageIDs[c.ImageID] = true
+	}
+
+	images, err := dockerClient.ImageList(ctx, types.ImageListOptions{All: true})
+	if err != nil {
+		log.Printf("Error get ImageList: %v", err)
+		panic(err)
+	}
+
+	for _, img := range images {
+		if !usedImageIDs[img.ID] {
+			fmt.Printf("Deleting unused image: %s\n", img.ID[:20])
+			_, err := dockerClient.ImageRemove(ctx, img.ID, types.ImageRemoveOptions{
+				Force:         false,
+				PruneChildren: false,
+			})
+			if err != nil || img.RepoTags == nil {
+				fmt.Printf("⚠️ Failed to delete %s: %v\n", img.ID[:20], err)
+			}
+
+			if mapDbImage[img.ID] == "" || mapDbImage[img.ID] != "deleted" {
+				imageStatusUpdate(img.RepoTags, mysqlClient, img.ID, "deleted")
+			}
+		} else {
+			if mapDbImage[img.ID] == "" || mapDbImage[img.ID] != "using" {
+				imageStatusUpdate(img.RepoTags, mysqlClient, img.ID, "using")
+			}
+		}
+	}
+}
+
+func getSavedImageInfo(
+	mysqlClient *sql.DB,
+) (map[string]string, error) {
+	dbImageList, err := mysqlops.SelectQueryRowsToStructs[shptypes.ImageStatus](mysqlClient,
+		"SELECT id, status FROM images")
+	if err != nil {
+		log.Printf("⚠️ Failed get Image Info in DB %v\n", err)
+		return nil, err
+	}
+	imageMap := make(map[string]string)
+
+	for _, img := range dbImageList {
+		imageMap[img.ID] = img.Status.String
+	}
+
+	return imageMap, nil
+}
+
+func imageStatusUpdate(
+	repoTags []string,
+	mysqlClient *sql.DB,
+	imageID string,
+	status string,
+) {
+	for _, tag := range repoTags {
+		parts := strings.SplitN(tag, ":", 2)
+		if len(parts) == 2 {
+			imageName := parts[0]
+			imageTag := parts[1]
+			upsertImageStatus(mysqlClient, imageID, imageName, imageTag, status)
+		}
+	}
+}
+
+func upsertImageStatus(
+	mysqlClient *sql.DB,
+	imageID string,
+	imageName string,
+	imageTag string,
+	status string,
+) {
+	log.Printf("Updating image %s status to %s", imageID, status)
+
+	_, err := mysqlops.ExecQuery(mysqlClient, `
+    INSERT INTO images (id, status, name, tag, last_check_time)
+    VALUES (?, ?, ?, ?, NOW())
+    ON DUPLICATE KEY UPDATE
+        status = VALUES(status),
+        last_check_time = NOW()`,
+		imageID, status, imageName, imageTag)
+
+	if err != nil {
+		log.Printf("Error upsert container status in MySQL: %v", err)
+	} else {
+		log.Printf("Image %s status upsert to %s successfully", imageID, status)
+	}
+}

--- a/internal/dockerops/types/types.go
+++ b/internal/dockerops/types/types.go
@@ -13,3 +13,8 @@ type ContainerStatus struct {
 	Name      sql.NullString `db:"container_name"`
 	DeletedAt sql.NullTime   `db:"deleted_at"`
 }
+
+type ImageStatus struct {
+	ID     string         `db:"id"`
+	Status sql.NullString `db:"status"`
+}

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -44,3 +44,21 @@ func CheckDockerStatus(
 		}
 	}
 }
+
+func CheckImageStatus(
+	ctx context.Context,
+	deps *appctx.Dependencies,
+) {
+	log.Println("Starting Docker CheckImageStatus...")
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Docker Image Status watcher stopped.")
+			return
+		default:
+			dockerops.WatchImageUsingStatus(ctx, deps.DockerClient, deps.MySQLClient)
+			time.Sleep(60 * time.Second)
+		}
+	}
+}


### PR DESCRIPTION
* 사용하지 않는 image docker container리스트와 비교해서 확인
* 메모리 관리를 위해 필요없는 image는 삭제
* 삭제와 모니터링 결과 db 업데이트
* 상태 변화 없을 시 db에 업데이트 하지 않도록 추가
* db update시 존재하면 update 존재하지 않으면 insert 되도록 함