### PR TITLE
FEAT: 이미지 모니터링 시 go 루틴 주기, 삭제 조건 변경

### DIFF
--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -51,14 +51,28 @@ func CheckImageStatus(
 ) {
 	clog.Debug("Starting Docker CheckImageStatus...")
 
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+
+	// ✅ 첫 1시간 대기
+	clog.Info("Initial wait for 1 hour before first WatchImageUsingStatus run")
+	select {
+	case <-ctx.Done():
+		clog.Error("Docker Image Status watcher stopped before first execution.")
+		return
+	case <-ticker.C:
+		// 첫 실행 시점 도달
+	}
+
+	// ✅ 이후 1시간마다 실행
 	for {
 		select {
 		case <-ctx.Done():
 			clog.Error("Docker Image Status watcher stopped.")
 			return
-		default:
+		case <-ticker.C:
+			clog.Info("Running WatchImageUsingStatus (every 1 hour)")
 			dockerops.WatchImageUsingStatus(ctx, deps.DockerClient, deps.MySQLClient)
-			time.Sleep(60 * time.Second)
 		}
 	}
 }


### PR DESCRIPTION
* 1분마다 실행 -> 1시간마다 실행되도록 주기 변경
* 기존 삭제 조건은 현재 컨테이너에 사용되지 않는 이미지라면 삭제처리 하였으나, 컨테이너 생성 중인 이미지도 삭제되는 문제가 있어 image 생성된지 1주일이 지났으며, 현재 컨테이너에서 사용중이 아니라면 삭제되도록 조건 변경